### PR TITLE
Update bugs content list

### DIFF
--- a/browser-support.html
+++ b/browser-support.html
@@ -12,14 +12,28 @@ copydoc: https://docs.google.com/document/d/1flcSinNnjOJw88ooVQfUjQW8ZDHSXOe2cTH
     <h1 class="p-heading--stylized u-no-margin--bottom">Browser support</h1>
   </div>
 </div>
-<div class="p-strip">
+<div class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <p class="p-heading--four">The Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design patterns do not have to look exactly the same on every browser.
-      </p>
-      <h3>How bugs are prioritised</h3>
-      <p>If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up. Priority level should be determined case by case If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised, and potentially marked as “Won’t fix” (this should be decided case by case).</p>
-      <h3>Supported browsers</h3>
+      <p class="p-heading--four">The Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design patterns do not have to look exactly the same on every browser.</p>
+      </div>
+      </div>
+      </div>
+      <div class="p-strip is-shallow">
+      <div class="row">
+        <div class="col-8">
+      <h2>How bugs are prioritised</h2>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised</li>
+          <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up</li>
+          <li class="p-list__item is-ticked">Priority level should be determined case by case</li>
+          <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised, and potentially marked as “Won’t fix” (this should be decided case by case).</li>
+        </ul>
+        </div>
+        </div>
+        <div class="row">
+          <div class="col-8">
+      <h2>Supported browsers</h2>
       <p>The following are the browsers that we actively test all patterns on. That does not mean other browsers are not supported or that bugs reported are not acted on.</p>
       <ul class="p-list--divided is-split">
         <li class="p-list__item"><span class="p-icon--chrome"></span>Chrome 55 or greater</li>
@@ -32,4 +46,4 @@ copydoc: https://docs.google.com/document/d/1flcSinNnjOJw88ooVQfUjQW8ZDHSXOe2cTH
       <p>We have a range of test devices that reflect the current marketplace and our own stats.</p>
     </div>
   </div>
-</div>
+  </div>

--- a/browser-support.html
+++ b/browser-support.html
@@ -15,24 +15,25 @@ copydoc: https://docs.google.com/document/d/1flcSinNnjOJw88ooVQfUjQW8ZDHSXOe2cTH
 <div class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <p class="p-heading--four">The Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design patterns do not have to look exactly the same on every browser.</p>
-      </div>
-      </div>
-      </div>
-      <div class="p-strip is-shallow">
-      <div class="row">
-        <div class="col-8">
+      <p class="p-heading--four">The Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of
+        access to visual and other enhancements — design patterns do not have to look exactly the same on every browser.</p>
+    </div>
+  </div>
+</div>
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-8">
       <h2>How bugs are prioritised</h2>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised</li>
-          <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up</li>
-          <li class="p-list__item is-ticked">Priority level should be determined case by case</li>
-          <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised, and potentially marked as “Won’t fix” (this should be decided case by case).</li>
-        </ul>
-        </div>
-        </div>
-        <div class="row">
-          <div class="col-8">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised</li>
+        <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up</li>
+        <li class="p-list__item is-ticked">Priority level should be determined case by case</li>
+        <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised, and potentially marked as “Won’t fix” (this should be decided case by case).</li>
+      </ul>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
       <h2>Supported browsers</h2>
       <p>The following are the browsers that we actively test all patterns on. That does not mean other browsers are not supported or that bugs reported are not acted on.</p>
       <ul class="p-list--divided is-split">
@@ -46,4 +47,4 @@ copydoc: https://docs.google.com/document/d/1flcSinNnjOJw88ooVQfUjQW8ZDHSXOe2cTH
       <p>We have a range of test devices that reflect the current marketplace and our own stats.</p>
     </div>
   </div>
-  </div>
+</div>


### PR DESCRIPTION
## Done
- Updated 'How bugs are prioritised' into a readable list
- Also updated headings to use `h2` for consistency across the site

## QA
- `./run`
- Visit http://0.0.0.0:8014/browser-support
- See that 'How bugs are prioritised' is now in a list

## Issue / Card
- Fixes https://github.com/canonical-web-and-design/vanillaframework.io/issues/220

## Screenshots
<img width="728" alt="Screenshot 2019-06-24 at 11 59 59" src="https://user-images.githubusercontent.com/17748020/60013976-c14f8700-9677-11e9-8d0f-b8b9445c7c88.png">
