### PR TITLE
Update Downloads section

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
 
 <div class="p-strip is-bordered is-deep">
   <div class="row">
-    <div class="col">
+    <div class="col-4">
       <h2>Downloads</h2>
     </div>
   </div>
@@ -115,7 +115,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         <p class="u-no-margin--bottom">
           <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">Download Vanilla Framework</a>
         </p>
-        <small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
+        <p><small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small></p>
       </div>
     </div>
     <div class="col-4">

--- a/index.html
+++ b/index.html
@@ -30,11 +30,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
           <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt="Lightweight pictogram" />
           <h3 class="p-heading-icon__title">Lightweight</h3>
         </div>
-        <p>
-          Vanilla contains a responsive CSS grid, basic style for HTML elements
-          and a selection of key useful patterns and utility classes that you
-          can extend.
-        </p>
+        <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
       </div>
     </div>
     <div class="col-4">
@@ -43,9 +39,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
           <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt="Composable pictogram" />
           <h3 class="p-heading-icon__title">Composable</h3>
         </div>
-        <p>
-          Vanilla is designed to be composable &mdash; you can include the whole framework to avail of all styles or you can use only what you need for your specific project.
-        </p>
+        <p>Vanilla is designed to be composable &mdash; you can include the whole framework to avail of all styles or you can use only what you need for your specific project.</p>
       </div>
     </div>
     <div class="col-4">
@@ -54,10 +48,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
           <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt="Open source pictogram" />
           <h3 class="p-heading-icon__title">Open source</h3>
         </div>
-        <p>
-          Anyone can contribute to Vanilla, improve it and extend it. All the
-          code is available on GitHub and is licensed under LGPLv3 by Canonical.
-        </p>
+        <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
       </div>
     </div>
   </div>
@@ -88,10 +79,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="row u-equal-height">
     <div class="col-4">
       <h2>Guidelines</h2>
-      <p>
-        If you are contributing to Vanilla, make sure to read and follow these
-        guidelines.
-      </p>
+      <p>If you are contributing to Vanilla, make sure to read and follow these guidelines.</p>
       <ul class="p-list--divided">
         <li class="p-list__item">
           <a href="/accessibility" class="p-link--soft">Accessibility&nbsp;&rsaquo;</a>
@@ -112,16 +100,16 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
 
 <div class="p-strip is-bordered is-deep">
   <div class="row">
-    <div class="col-12">
+    <div class="col">
       <h2>Downloads</h2>
     </div>
   </div>
   <div class="row">
     <div class="col-4">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub icon" style="max-height: 2.5rem; max-width: 2.5rem;">
-          <h3 class="p-heading-icon__title">Vanilla Framework</h3>
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg">
+          <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
         <p class="u-no-margin--bottom">
@@ -131,23 +119,22 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
       </div>
     </div>
     <div class="col-4">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch icon" style="max-height: 2.5rem; max-width: 2.5rem;">
-          <h3 class="p-heading-icon__title">Vanilla Design</h3>
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg">
+          <h4 class="p-heading-icon__title">Vanilla Design</h4>
         </div>
         <p>Get a Sketch file of common design components.</p>
         <p>
-          <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Vanilla Design UI Kit</a>
+          <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Vanilla Design UI Kit</a><small>(2.4 MB)</small>
         </p>
-        <small>(2.4 MB)</small>
       </div>
     </div>
     <div class="col-4">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a279238b-react-logo.svg" alt="React icon" style="max-height: 2.5rem; max-width: 2.5rem;">
-          <h3 class="p-heading-icon__title">Vanilla React</h3>
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a279238b-react-logo.svg">
+          <h4 class="p-heading-icon__title">Vanilla React</h4>
         </div>
         <p>A simple implementation of Vanilla Framework using React.</p>
         <p>
@@ -168,67 +155,50 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="row">
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://www.ubuntu.com/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="Ubuntu" />
-      </a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="Ubuntu" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://maas.io/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/e9b70f82-2018-logo-maas.svg" alt="MAAS" />
-      </a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/e9b70f82-2018-logo-maas.svg" alt="MAAS" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://jaas.ai/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/89488d9e-2018-logo-juju.svg" alt="Juju" />
-      </a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/89488d9e-2018-logo-juju.svg" alt="Juju" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://snapcraft.io/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="Snapcraft" />
-      </a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="Snapcraft" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://linuxcontainers.org/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/a8e53531-2018-logo-lxd.svg" alt="LXD" />
-      </a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/a8e53531-2018-logo-lxd.svg" alt="LXD" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://conjure-up.io/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/f730b69a-2018-logo-conjure-up.svg" alt="Conjure Up" />
-      </a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/f730b69a-2018-logo-conjure-up.svg" alt="Conjure Up" /></a>
     </div>
   </div>
 </div>
 
-<div class="p-strip--light is-deep">
+<div class="p-strip--light">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h2 class="p-heading--three">Get involved</h2>
       <ul class="p-list--divided">
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg'); background-size: 1rem;">
-          <a href="https://vanillaframework.slack.com"
-            class="p-link--soft">
-            Slack&nbsp;&rsaquo;
-          </a>
+          <a href="https://vanillaframework.slack.com" class="p-link--soft">Slack&nbsp;&rsaquo;</a>
         </li>
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/7eae50ca-icon-twitter.svg'); background-size: 1rem;">
-          <a href="https://twitter.com/vanillaframewrk"
-            class="p-link--soft">
-            Twitter&nbsp;&rsaquo;
-          </a>
+          <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
         </li>
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/f307a122-icon-github.svg'); background-size: 1rem;">
-          <a href="https://github.com/canonical-web-and-design/vanilla-framework"
-            class="p-link--soft">
-            GitHub&nbsp;&rsaquo;
-          </a>
+          <a href="https://github.com/canonical-web-and-design/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
         </li>
       </ul>
     </div>
     <div class="col-8 p-divider__block">
       <h3>Subscribe to Vanilla updates</h3>
-      <p>
-        Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.
-      </p>
+      <p>Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
       <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form p-form--inline">
         <div class="p-form__group">
           <label class="u-off-screen" for="mce-EMAIL">Email address</label>


### PR DESCRIPTION
## Done
- Updated 'Downloads' section to use `p.heading-small` component

## QA
- `./run`
- Visit http://0.0.0.0:8014/
- Scroll to Downloads and see that it looks amazing 😉 

## Issue / Card
- Fixes https://github.com/canonical-web-and-design/vanillaframework.io/issues/223

## Screenshots
<img width="736" alt="Screenshot 2019-06-24 at 14 11 58" src="https://user-images.githubusercontent.com/17748020/60021508-0c729580-968a-11e9-8912-47ffa73af7bf.png">

