### PR TITLE
Bump linked vanilla version to 2.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
-        <a href=" https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.1" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.0.1', 'eventValue' : undefined });" class="p-button--positive p-link--external">Download v2.0.1</a>
+        <a href=" https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.1.0', 'eventValue' : undefined });" class="p-button--positive p-link--external">Download v2.1.0</a>
       </li>
       <li class="p-inline-list__item">
         <a href="https://docs.vanillaframework.io/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--neutral">Get started</a>


### PR DESCRIPTION
## Done

Updated the homepage link to download vanilla to 2.1.0

## QA

- `./run`
- http://0.0.0.0:8014/ see the updated list