### PR TITLE
Upgrade to v2.3.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
-        <a href=" https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.2.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.2.0', 'eventValue' : undefined });" class="p-button--positive p-link--external">Download v2.2.0</a>
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.3.0', 'eventValue' : undefined });" class="p-button--positive p-link--external">Download v2.3.0</a>
       </li>
       <li class="p-inline-list__item">
         <a href="https://docs.vanillaframework.io/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--neutral">Get started</a>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node-sass": "4.12.0",
     "postcss-cli": "6.1.3",
     "sass-lint": "1.13.1",
-    "vanilla-framework": "2.2.0",
+    "vanilla-framework": "2.3.0",
     "watch-cli": "0.2.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,9 +3580,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.2.0.tgz#c098b030f261bd321b55f6473e3ce614cb701e1f"
+vanilla-framework@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.3.0.tgz#420925e905ce451273bc54c8e5792f58fdd0ddf4"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
- Updated package.json and yarn.lock file to v2.3.0
- Update to homepage link to v2.3.0 and point to the latest release: https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0

## QA
- ./run
- Visit http://0.0.0.0:8014/
- Check the site looks good and nothing is broken 😉 