### PR TITLE
Reduce size and add alt tags to images

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ sitemap:
 copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g7O3rLzpg/edit
 ---
 
-<div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/b54d869a-vanilla-grad-background-min.png'); background-position: 75% 50%;">
+<div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/b70dcf07-vanilla-grad-background-min.png'); background-position: 75% 50%;">
   <div class="row">
     <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
     <ul class="p-inline-list">
@@ -27,7 +27,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt="Lightweight pictogram" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt="lightweight pictogram" />
           <h3 class="p-heading-icon__title">Lightweight</h3>
         </div>
         <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
@@ -36,7 +36,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt="Composable pictogram" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt="composable pictogram" />
           <h3 class="p-heading-icon__title">Composable</h3>
         </div>
         <p>Vanilla is designed to be composable &mdash; you can include the whole framework to avail of all styles or you can use only what you need for your specific project.</p>
@@ -45,7 +45,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt="Open source pictogram" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt="open source pictogram" />
           <h3 class="p-heading-icon__title">Open source</h3>
         </div>
         <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
@@ -93,7 +93,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
       </ul>
     </div>
     <div class="col-8 u-vertically-center u-align--center">
-      <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/739d1f1f-guidelines-illustration.svg" alt="">
+      <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg" alt="guidelines illustration">
     </div>
   </div>
 </div>
@@ -108,7 +108,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="github icon" />
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
@@ -121,7 +121,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="sketch icon" />
           <h4 class="p-heading-icon__title">Vanilla Design</h4>
         </div>
         <p>Get a Sketch file of common design components.</p>
@@ -133,7 +133,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a279238b-react-logo.svg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a279238b-react-logo.svg" alt="react icon" />
           <h4 class="p-heading-icon__title">Vanilla React</h4>
         </div>
         <p>A simple implementation of Vanilla Framework using React.</p>
@@ -155,28 +155,28 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="row">
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://www.ubuntu.com/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="Ubuntu" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="ubuntu logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://maas.io/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/e9b70f82-2018-logo-maas.svg" alt="MAAS" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/e9b70f82-2018-logo-maas.svg" alt="MAAS logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://jaas.ai/">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="Juju" />
+        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="juju logo" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://snapcraft.io/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="Snapcraft" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="snapcraft logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://linuxcontainers.org/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/a8e53531-2018-logo-lxd.svg" alt="LXD" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/a8e53531-2018-logo-lxd.svg" alt="LXD logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://conjure-up.io/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/f730b69a-2018-logo-conjure-up.svg" alt="Conjure Up" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/f730b69a-2018-logo-conjure-up.svg" alt="conjure up logo" /></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
- Improve the performance
- Reduce the size of image assets
- Add `alt` tags to images without

## QA
- Pull code
- `./run`
- Visit http://0.0.0.0:8014/