### PR TITLE
Update content on /contribute page

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -62,11 +62,9 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
   </div>
   <div class="row">
     <div class="col-6">
-      <p>When <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose" class="p-link--external">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template
-        for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
+      <p>When <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose" class="p-link--external">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
       <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
-      <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to
-        upstream/master.</p>
+      <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to upstream/master.</p>
       <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
     </div>
     <div class="col-6">
@@ -108,9 +106,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
         </div>
       </div>
       <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/engine/installation/" class="p-link--external">install Docker</a>, and then use the <code>./run</code> script to <a
-          href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-local-development" class="p-link--external">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off
-        the
-        tests for your project, in the terminal <code>./run test</code>.</p>
+          href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-local-development" class="p-link--external">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>./run test</code>.</p>
     </div>
     <div class="col-6">
       <div class="p-heading-icon">
@@ -119,9 +115,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
           <h3 class="p-heading-icon__title">Licences</h3>
         </div>
       </div>
-      <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="p-link--external">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used
-        to
-        format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html" class="p-link--external">LGPLv3</a> by <a href="https://www.canonical.com/" class="p-link--external">Canonical Ltd</a>.</p>
+      <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="p-link--external">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used to format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html" class="p-link--external">LGPLv3</a> by <a href="https://www.canonical.com/" class="p-link--external">Canonical Ltd</a>.</p>
     </div>
   </div>
 </div>

--- a/contribute.html
+++ b/contribute.html
@@ -93,7 +93,6 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     </div>
   </div>
 </div>
-
 <div class="p-strip">
   <div class="row">
     <div class="col-6">

--- a/contribute.html
+++ b/contribute.html
@@ -13,7 +13,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     <h1 class="p-heading--stylized u-no-margin--bottom">Contribute</h1>
   </div>
 </div>
-<div class="p-strip">
+<div class="p-strip is-bordered">
   <div class="row">
     <h2>Meet the team</h2>
   </div>
@@ -56,54 +56,73 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     </div>
   </div>
 </div>
-<div class="row">
-  <hr>
-</div>
-<div class="p-strip">
+<div class="p-strip is-bordered">
   <div class="row">
     <h2>Contribute</h2>
   </div>
   <div class="row">
-    <div class="col-8">
-      <p>When <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose" class="p-link--external">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
+    <div class="col-6">
+      <p>When <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose" class="p-link--external">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template
+        for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
       <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
-      <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to upstream/master.</p>
+      <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to
+        upstream/master.</p>
       <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
     </div>
-    <div class="col-4">
-      <div class="p-card is-bordered">
-        <h3>File a request/bug</h3>
-        <p>We use <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues" class="p-link--external">GitHub issues</a> to track all our bugs and feature requests.</p>
+    <div class="col-6">
+      <div class="row">
+        <div class="col-6 p-card">
+          <h3>Guidelines</h3>
+          <p>We follow two guideline documents that align with the practices that the Canonical Web Team follows across all projects.
+            <ul class="p-inline-list--middot" style="margin-bottom: 0px;">
+              <li class="p-inline-list__item"> <a href="https://canonical-web-and-design.github.io/practices/coding/html.html" class="p-link--external">HTML code standards</a> </li>
+              <li class="p-inline-list__item"> <a href="https://canonical-web-and-design.github.io/practices/coding/stylesheets.html" class="p-link--external">Stylesheets code standards</a> </li>
+            </ul>
+        </div>
       </div>
-      <div class="p-card is-bordered">
-        <h3>Chat with us</h3>
-        <p>Find out about new releases, latest features and get help on <a href="https://twitter.com/vanillaframewrk" class="p-link--external">Twitter</a>.</p>
+      <div class="row">
+        <div class="col-3 p-card">
+          <h3>File a bug</h3>
+          <p>We use <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues" class="p-link--external">GitHub issues</a> to track all our bugs and feature requests.</p>
+        </div>
+        <div class="col-3 p-card">
+          <h3>Chat with us</h3>
+          <p>Find out about new releases, latest features and get help on <a href="https://twitter.com/vanillaframewrk" class="p-link--external">Twitter</a>.</p>
+        </div>
       </div>
     </div>
   </div>
 </div>
-<div class="row">
-  <hr>
-</div>
+
 <div class="p-strip">
   <div class="row">
     <div class="col-6">
       <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          <svg width="60" height="60" class="p-heading-icon__img" viewBox="0 0 12 16" version="1.1" aria-hidden="true"><title>GitHub pull requist icon</title><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
+        <div class="p-heading-icon__header is-stacked">
+          <svg width="60" height="60" class="p-heading-icon__img" viewBox="0 0 12 16" version="1.1" aria-hidden="true">
+            <title>GitHub pull requist icon</title>
+            <path fill-rule="evenodd"
+              d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z">
+            </path>
+          </svg>
           <h3 class="p-heading-icon__title">Running tests locally</h3>
         </div>
       </div>
-      <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/engine/installation/" class="p-link--external">install Docker</a>, and then use the <code>./run</code> script to <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-local-development" class="p-link--external">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>./run test</code>.</p>
+      <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/engine/installation/" class="p-link--external">install Docker</a>, and then use the <code>./run</code> script to <a
+          href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-local-development" class="p-link--external">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off
+        the
+        tests for your project, in the terminal <code>./run test</code>.</p>
     </div>
     <div class="col-6">
       <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
+        <div class="p-heading-icon__header is-stacked">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical logo">
           <h3 class="p-heading-icon__title">Licences</h3>
         </div>
       </div>
-      <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="p-link--external">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used to format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html" class="p-link--external">LGPLv3</a> by <a href="https://www.canonical.com/" class="p-link--external">Canonical Ltd</a>.</p>
+      <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="p-link--external">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used
+        to
+        format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html" class="p-link--external">LGPLv3</a> by <a href="https://www.canonical.com/" class="p-link--external">Canonical Ltd</a>.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
- Updated copy based on new edits inside [copy doc](https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv39CW4kkwo/edit#) to add coding standards content to contribute
- New layout under _Contribute_ section
- Added `is-bordered` to rows and removed `hr` dividers
- Updated base section from default to `is-stacked`

## QA
- Pull code
- `./run`
- Visit http://0.0.0.0:8014/contribute

## Screenshot
<img width="1439" alt="Screenshot 2019-09-19 at 14 16 30" src="https://user-images.githubusercontent.com/17748020/65243166-1ae51780-dae8-11e9-96de-8d64c9a44c64.png">
