### PR TITLE
Update 404 template

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,9 +7,18 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div class="p-strip is-deep">
+<div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
-    <h1>404: Page not found</h1>
-    <p class="p-heading--four" style="max-width: none">Sorry, we can't find the page you're looking for.<br>If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanillaframework.io/issues/new">file a bug.</a></p>
+    <div class="col 12">
+      <h1 class="p-heading--stylized">404 - Page not found</h1>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col 12">
+      <p>Sorry, we can't find the page you're looking for. If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanillaframework.io/issues/new">file a bug on GitHub.</a></p>
+    </div>
   </div>
 </div>

--- a/404.html
+++ b/404.html
@@ -7,10 +7,10 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div id="main-content" class="p-strip--image is-dark vfio-hero">
+<div id="main-content" class="p-strip--image is-dark vfio-hero" style="background-color: #333333">
   <div class="row">
     <div class="col 12">
-      <h1 class="p-heading--stylized">404 - Page not found</h1>
+      <h1>404 - Page not found</h1>
     </div>
   </div>
 </div>

--- a/404.html
+++ b/404.html
@@ -10,7 +10,7 @@ sitemap:
 <div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
     <div class="col 12">
-      <h1>404 - Page not found</h1>
+      <h1 class="u-no-margin--bottom">404 - Page not found</h1>
     </div>
   </div>
 </div>

--- a/404.html
+++ b/404.html
@@ -7,7 +7,7 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div id="main-content" class="p-strip--image is-dark vfio-hero" style="background-color: #333333">
+<div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
     <div class="col 12">
       <h1>404 - Page not found</h1>


### PR DESCRIPTION
## Done

- Added Suru hero background
- Split title and content into two sections

## QA

- Pull code
- `./run`
- Visit http://0.0.0.0:8014/karlos
- See new 404-page template in all its glory

## Issue / Card

Fixes the current style and format.

<img width="1438" alt="Screenshot 2019-10-17 at 16 34 07" src="https://user-images.githubusercontent.com/17748020/67024235-fa66a800-f0fb-11e9-935c-e94b1fe65e7a.png">

## Screenshots

<img width="1440" alt="Screenshot 2019-10-17 at 16 34 47" src="https://user-images.githubusercontent.com/17748020/67024280-0d797800-f0fc-11e9-970e-b9eef36d58ba.png">

