### PR TITLE
Update 500 template

### DIFF
--- a/500.html
+++ b/500.html
@@ -7,19 +7,18 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div class="p-strip--light is-deep u-no-padding--bottom">
+<div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
-    <div class="u-equal-height">
-      <div class="col-6 u-vertically-center">
-      <div>
-        <h1>500: Internal server error</h1>
-        <p class="p-heading--four">Something went wrong on our end.</p>
-        <p>If you have the time, please help us out by <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">filing a bug.</a></p>
-      </div>
+    <div class="col 12">
+      <h1 class="p-heading--stylized">500 - Internal server error</h1>
     </div>
-      <div class="col-6">
-      <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg" alt="">
-    </div>
+  </div>
+</div>
+
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col 12">
+      <p>Something went wrong on our end. If you have the time, please help us out by <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">filing a bug.</a></p>
     </div>
   </div>
 </div>

--- a/500.html
+++ b/500.html
@@ -7,10 +7,10 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div id="main-content" class="p-strip--image is-dark vfio-hero">
+<div id="main-content" class="p-strip--image is-dark vfio-hero" style="background-color: #333333">
   <div class="row">
     <div class="col 12">
-      <h1 class="p-heading--stylized">500 - Internal server error</h1>
+      <h1>500 - Internal server error</h1>
     </div>
   </div>
 </div>

--- a/500.html
+++ b/500.html
@@ -7,7 +7,7 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div id="main-content" class="p-strip--image is-dark vfio-hero" style="background-color: #333333">
+<div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
     <div class="col 12">
       <h1>500 - Internal server error</h1>

--- a/500.html
+++ b/500.html
@@ -10,7 +10,7 @@ sitemap:
 <div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
     <div class="col 12">
-      <h1>500 - Internal server error</h1>
+      <h1 class="u-no-margin--bottom">500 - Internal server error</h1>
     </div>
   </div>
 </div>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -21,6 +21,7 @@ $sticky-footer: true;
 .vfio-hero {
   background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png');
   background-position: 75% 50%;
+  background-color: #e95420;
 }
 
 .p-list__icon--github {


### PR DESCRIPTION
## Done

- Added Suru hero background
- Split title and content into two sections

## QA

- Pull code
- `./run`
- Visit http://0.0.0.0:8014/500
- See new 500-page template in all its glory

## Issue / Card

Fixes the current style and format.

<img width="1439" alt="Screenshot 2019-10-17 at 16 45 55" src="https://user-images.githubusercontent.com/17748020/67025357-cee4bd00-f0fd-11e9-854f-241011d64afd.png">

## Screenshots

<img width="1438" alt="Screenshot 2019-10-17 at 16 46 03" src="https://user-images.githubusercontent.com/17748020/67025319-bd031a00-f0fd-11e9-8211-bba79b1d069e.png">

