### PR TITLE
Copy changes to home hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,14 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
 
 <div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/b70dcf07-vanilla-grad-background-min.png'); background-position: 75% 50%;">
   <div class="row">
-    <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
-    <ul class="p-inline-list">
+    <h1>A simple extensible CSS framework</h1>
+    <p>Backed by open-source code and written is Sass by the Canonical Web Team.</p>
+    <ul class="p-inline-list u-no-margin--bottom">
       <li class="p-inline-list__item">
-        <a href="https://docs.vanillaframework.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive">Get started</a>
+        <a href="https://docs.vanillaframework.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.4.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.4.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external">Download v2.4.0</a>
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.4.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.4.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v2.4.0</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Done

- Removed Vanilla from the hero section heading (as it's visible in the nav - Vanilla to repetitive)
- Updated 'Ubuntu Web Team' to 'Canonical Web Team'
- Removed bottom-margin on buttons to align the top and bottom paddings on the background image
- Removed `p-heading--stylized` class as it's no longer needed as `h1` comes styled with thin font by default now 

## QA

- Pull code
- `./run`
- Visit http://0.0.0.0:8014/
- See new copy changes

## Screenshots

<img width="1438" alt="Screenshot 2019-10-21 at 10 33 12" src="https://user-images.githubusercontent.com/17748020/67194037-43657780-f3ee-11e9-86ab-4a5301210869.png">

