### PR TITLE
Update logo examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
-      <a href="https://aliceos.app/">
+      <a href="https://docs.aliceos.app/master/index.html">
         <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/07efa0fc-2019-alice-os-logo.svg" alt="aliceos logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">

--- a/index.html
+++ b/index.html
@@ -138,25 +138,25 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="ubuntu logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
-        <a href="https://maas.io">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/e9b70f82-2018-logo-maas.svg" alt="MAAS logo" /></a>
+        <a href="http://elmtherapy.co.uk/">
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7c028f73-2019-elm-therapy-logo.svg" alt="elm therapy logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://jaas.ai">
-        <img class="b-lazy"  src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="juju logo" />
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="jaas logo" />
       </a>
+    </div>
+    <div class="col-small-2 col-medium-2 col-2">
+      <a href="https://aliceos.app/">
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/07efa0fc-2019-alice-os-logo.svg" alt="aliceos logo" /></a>
+    </div>
+    <div class="col-small-2 col-medium-2 col-2">
+      <a href="https://stmargarets.london/">
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg" alt="st margarets logo" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://snapcraft.io">
         <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="snapcraft logo" /></a>
-    </div>
-    <div class="col-small-2 col-medium-2 col-2">
-      <a href="https://linuxcontainers.org">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/a8e53531-2018-logo-lxd.svg" alt="LXD logo" /></a>
-    </div>
-    <div class="col-small-2 col-medium-2 col-2">
-      <a href="https://conjure-up.io">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/f730b69a-2018-logo-conjure-up.svg" alt="conjure up logo" /></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
- Updated 'Who's using Vanilla' examples
- Added Elm Therapy, AliceOS, and St Margarets
- Logos link to site examples
- #winning #opensourceprojects

## QA

- Pull code
- Run ./run
- Open http://0.0.0.0:8014/
- Scroll to 'Who's using Vanilla' at the bottom of the page and see new logos

## Issue / Card

Previously discussed in a Design review meeting, we have other projects outside of the Canonical org under /showcase using Vanilla, we should add them to the homepage, rather than it being all Canonical products.

## Screenshots

<img width="1440" alt="Screenshot 2019-10-24 at 16 43 33" src="https://user-images.githubusercontent.com/17748020/67502455-cb14e580-f67d-11e9-8e66-ebb13f06498e.png">

