### PR TITLE
Add blog feeds section

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,19 +134,19 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="row">
       <div class="col-3">
         <h4><a href="https://ubuntu.com/blog/vanilla-framework-2-0-upgrade-guide">Vanilla Framework 2.0 upgrade guide</a></h4>
-        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">20 June 2019</time></em></p>
+        <p class="p-heading--six">20 June 2019</p>
       </div>
       <div class="col-3">
         <h4><a href="https://ubuntu.com/blog/new-release-vanilla-framework-2-0">New release: Vanilla framework 2.0</a></h4>
-        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">13 June 2019</time></em></p>
+        <p class="p-heading--six">13 June 2019</p>
       </div>
       <div class="col-3">
         <h4><a href="https://ubuntu.com/blog/a-fresh-look-for-releases-ubuntu-com">A fresh look for releases.ubuntu.com</a></h4>
-        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">13 February 2019</time></em></p>
+        <p class="p-heading--six">13 February 2019</p>
       </div>
       <div class="col-3">
         <h4><a href="https://ubuntu.com/blog/vertical-rhythm-and-spacing-improvements-in-vanilla-framework-2-0">Vertical rhythm and spacing in Vanilla Framework 2.0</a></h4>
-        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">15 March 2019</time></em></p>
+        <p class="p-heading--six">15 March 2019</p>
       </div>
       <div class="u-fixed-width" style="padding-left: 0px;"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         <h4><a href="https://ubuntu.com/blog/vertical-rhythm-and-spacing-improvements-in-vanilla-framework-2-0">Vertical rhythm and spacing in Vanilla Framework 2.0</a></h4>
         <p class="p-heading--six">15 March 2019</p>
       </div>
-      <div class="u-fixed-width" style="padding-left: 0px;"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
+      <div class="u-fixed-width u-no-padding--right u-no-padding--left"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -128,6 +128,31 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   </div>
 </div>
 
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <h2>Latest news from our blog</h2>
+    <div class="row">
+      <div class="col-3">
+        <h4><a href="https://ubuntu.com/blog/vanilla-framework-2-0-upgrade-guide">Vanilla Framework 2.0 upgrade guide</a></h4>
+        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">20 June 2019</time></em></p>
+      </div>
+      <div class="col-3">
+        <h4><a href="https://ubuntu.com/blog/new-release-vanilla-framework-2-0">New release: Vanilla framework 2.0</a></h4>
+        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">13 June 2019</time></em></p>
+      </div>
+      <div class="col-3">
+        <h4><a href="https://ubuntu.com/blog/a-fresh-look-for-releases-ubuntu-com">A fresh look for releases.ubuntu.com</a></h4>
+        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">13 February 2019</time></em></p>
+      </div>
+      <div class="col-3">
+        <h4><a href="https://ubuntu.com/blog/vertical-rhythm-and-spacing-improvements-in-vanilla-framework-2-0">Vertical rhythm and spacing in Vanilla Framework 2.0</a></h4>
+        <p class="u-no-padding--top"><em><time pubdate="" class="article-time">15 March 2019</time></em></p>
+      </div>
+      <div class="u-fixed-width" style="padding-left: 0px;"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
+    </div>
+  </div>
+</div>
+
 <div class="p-strip is-bordered">
   <div class="row">
     <h2 class="p-muted-heading u-align-text--center">Who&rsquo;s using Vanilla</h2>


### PR DESCRIPTION
## Done

- Added blog section above 'Who's using Vanilla'
- Displaying 4 latest articles from Vanilla team
- CTA button links to https://ubuntu.com/blog/topics/design

## QA

- Pull code
- Run ./run
- Open http://0.0.0.0:8014/
- Scroll to 'Latest news from our blog' and check articles are visible and link

## Issue / Card

Fixes https://github.com/canonical-web-and-design/vanillaframework.io/issues/248

## Screenshots

<img width="1440" alt="Screenshot 2019-10-28 at 11 30 51" src="https://user-images.githubusercontent.com/17748020/67675297-b5056e80-f976-11e9-8b66-c5dfbc8268ca.png">

