### PR TITLE
Add GitHub buttons to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ sitemap:
 copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g7O3rLzpg/edit
 ---
 
-<script async defer src="https://buttons.github.io/buttons.js"></script>
+<script defer src="https://buttons.github.io/buttons.js"></script>
 
 <div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/b70dcf07-vanilla-grad-background-min.png'); background-position: 75% 50%;">
   <div class="row">

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@ sitemap:
 copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g7O3rLzpg/edit
 ---
 
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+
 <div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/b70dcf07-vanilla-grad-background-min.png'); background-position: 75% 50%;">
   <div class="row">
     <h1>A simple extensible CSS framework</h1>
@@ -153,7 +155,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip">
   <div class="row">
     <h2 class="p-muted-heading u-align-text--center">Who&rsquo;s using Vanilla</h2>
   </div>
@@ -188,7 +190,13 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
 
 <div class="p-strip--light">
   <div class="row">
-    <div class="col-4">
+    <div class="col-3">
+      <h2 class="p-heading--three">Contribute</h2>
+      <p><a class="github-button" href="https://github.com/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
+      <p><a class="github-button" href="https://github.com/vanilla-framework/vanilla-framework" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star vanilla-framework/vanilla-framework on GitHub">Star</a></p>
+      <a class="github-button" href="https://github.com/vanilla-framework/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a>
+    </div>
+    <div class="col-3">
       <h2 class="p-heading--three">Get involved</h2>
       <ul class="p-list--divided">
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg'); background-size: 1rem;">
@@ -202,7 +210,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         </li>
       </ul>
     </div>
-    <div class="col-8">
+    <div class="col-6">
       <h3>Subscribe to Vanilla updates</h3>
       <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
         <div class="p-form__group">


### PR DESCRIPTION
## Done

- Added GitHub buttons - https://buttons.github.io/
- Add to the bottom of the page along with social and subscribe

## QA

- Pull code
- Run ./run
- Open http://0.0.0.0:8014/
- Scroll to the bottom of the page and see 'Contribute' 
- Click GitHub buttons and make sure they link to the correct page

## Screenshots

<img width="1440" alt="Screenshot 2019-11-08 at 14 35 25" src="https://user-images.githubusercontent.com/17748020/68484465-37264a80-0235-11ea-8807-dffb1c9bd1f2.png">