### PR TITLE
Update GitHub follow link

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,8 +193,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-3">
       <h2 class="p-heading--three">Contribute</h2>
       <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
-      <p><a class="github-button" href="https://github.com/vanilla-framework/vanilla-framework" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star vanilla-framework/vanilla-framework on GitHub">Star</a></p>
-      <a class="github-button" href="https://github.com/vanilla-framework/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a>
+      <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
     </div>
     <div class="col-3">
       <h2 class="p-heading--three">Get involved</h2>

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="row">
     <div class="col-3">
       <h2 class="p-heading--three">Contribute</h2>
-      <p><a class="github-button" href="https://github.com/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
+      <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
       <p><a class="github-button" href="https://github.com/vanilla-framework/vanilla-framework" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star vanilla-framework/vanilla-framework on GitHub">Star</a></p>
       <a class="github-button" href="https://github.com/vanilla-framework/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a>
     </div>


### PR DESCRIPTION
## Done

- Updated 'Follow @vanilla-framework' button to correct link
- No longer 404's
- Pulls in number of follows 👍 

## QA

- Pull code
- Run ./run
- Open http://0.0.0.0:8014/ or view demo link https://vanillaframework-io-canonical-web-and-design-pr-270.run.demo.haus/
- Scroll to the bottom of the page 'Contribute' and check 'Follow @vanilla-framework' button links to Vanilla Framework repository and doesn't 404

## Screenshots

<img width="341" alt="Screenshot 2019-12-10 at 12 54 16" src="https://user-images.githubusercontent.com/17748020/70531241-67bb1600-1b4c-11ea-9d40-87bd7ba75815.png">
