### PR TITLE
Add examples to main navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,6 +19,7 @@
       </span>
       <ul class="p-navigation__links">
         <li class="p-navigation__link"><a href="https://docs.vanillaframework.io">Docs</a></li>
+        <li class="p-navigation__link"><a href="https://docs.vanillaframework.io/examples">Examples</a></li>
         <li class="p-navigation__link{% if page.url == '/accessibility.html' %} is-selected{% endif %}"><a href="/accessibility">Accessibility</a></li>
         <li class="p-navigation__link{% if page.url == '/browser-support.html' %} is-selected{% endif %}"><a href="/browser-support">Browser support</a></li>
         <li class="p-navigation__link{% if page.url == '/contribute.html' %} is-selected{% endif %}"><a href="/contribute">Contribute</a></li>


### PR DESCRIPTION
## Done

Adds "Examples" link to main navigation for consistency with docs.

Fixes #274 

## QA

- ./run or [demo](https://vanillaframework-io-canonical-web-and-design-pr-278.run.demo.haus/)
- Go to home page
- Check for "Examples" link in main navigation
- Link should lead to examples page in docs

## Screenshots

<img width="1301" alt="Screenshot 2020-01-24 at 13 27 28" src="https://user-images.githubusercontent.com/83575/73069161-49676a80-3ead-11ea-9823-533d5cfea49d.png">

