### PR TITLE
Corrects alt= text across the site

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
           class="b-lazy p-navigation__image"
           src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
           data-src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg"
-          alt="Vanilla framework logo">
+          alt="Vanilla">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/contribute.html
+++ b/contribute.html
@@ -21,7 +21,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     <div class="col-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b943a4e7-ant.jpeg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b943a4e7-ant.jpeg" alt="">
           <h4 class="p-heading-icon__title"><a href="https://github.com/anthonydillon">anthonydillon</a></h4>
         </div>
         <p>Lead Web Developer</p>
@@ -30,7 +30,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     <div class="col-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/fced2b0d-kwm14-avater.jpeg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/fced2b0d-kwm14-avater.jpeg" alt="">
           <h4 class="p-heading-icon__title"><a href="https://github.com/kwm14">kwm14</a></h4>
         </div>
         <p>Lead Visual Designer</p>
@@ -39,7 +39,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     <div class="col-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9d912294-deadlight.jpeg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9d912294-deadlight.jpeg" alt="">
           <h4 class="p-heading-icon__title"><a href="https://github.com/deadlight">deadlight</a></h4>
         </div>
         <p>Web Developer</p>
@@ -48,7 +48,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     <div class="col-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/59a13d9e-lyubomir-popov-avater.jpeg">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/59a13d9e-lyubomir-popov-avater.jpeg" alt="">
           <h4 class="p-heading-icon__title"><a href="https://github.com/lyubomir-popov">lyubomir-popov</a></h4>
         </div>
         <p>Senior Visual Designer</p>
@@ -111,7 +111,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
     <div class="col-6">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical logo">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="">
           <h3 class="p-heading-icon__title">Licences</h3>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt="lightweight pictogram" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt="" />
           <h3 class="p-heading-icon__title">Lightweight</h3>
         </div>
         <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
@@ -39,7 +39,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt="composable pictogram" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt="" />
           <h3 class="p-heading-icon__title">Composable</h3>
         </div>
         <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
@@ -48,7 +48,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt="open source pictogram" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt="" />
           <h3 class="p-heading-icon__title">Open source</h3>
         </div>
         <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
@@ -93,7 +93,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
       </ul>
     </div>
     <div class="col-8 u-vertically-center u-align--center">
-      <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg" alt="guidelines illustration">
+      <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg" alt="">
     </div>
   </div>
 </div>
@@ -108,7 +108,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="p-card--highlighted col-4">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="github icon" />
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
@@ -119,7 +119,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="p-card--highlighted col-4">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="sketch icon" />
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
           <h4 class="p-heading-icon__title">Vanilla Design</h4>
         </div>
         <p>Get our Sketch library of common design components.</p>
@@ -162,28 +162,28 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="row">
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://ubuntu.com">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="ubuntu logo" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="Ubuntu" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
         <a href="http://elmtherapy.co.uk/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7c028f73-2019-elm-therapy-logo.svg" alt="elm therapy logo" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7c028f73-2019-elm-therapy-logo.svg" alt="Elm Therapy" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://jaas.ai">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="jaas logo" />
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="JAAS" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://docs.aliceos.app/master/index.html">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/07efa0fc-2019-alice-os-logo.svg" alt="aliceos logo" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/07efa0fc-2019-alice-os-logo.svg" alt="AliceOS" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://stmargarets.london/">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg" alt="st margarets logo" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg" alt="St Margarets" /></a>
     </div>
     <div class="col-small-2 col-medium-2 col-2">
       <a href="https://snapcraft.io">
-        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="snapcraft logo" /></a>
+        <img class="b-lazy" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="Snapcraft" /></a>
     </div>
   </div>
 </div>

--- a/showcase.html
+++ b/showcase.html
@@ -26,12 +26,12 @@ copydoc: https://docs.google.com/document/d/1daLrp_H_BGhSefvrP-aj3v3505dEz-zoKF2
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/25df3b87-ubuntu-vf.io-showcase.png" alt="Ubuntu screenshot">
+      <img src="https://assets.ubuntu.com/v1/25df3b87-ubuntu-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="http://ubuntu.com">Ubuntu</a></h3>
       <p>Ubuntu is an open source software operating system.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/e8ea14f4-maas-vf.io-showcase.png" alt="MAAS screenshot">
+      <img src="https://assets.ubuntu.com/v1/e8ea14f4-maas-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="http://maas.io">MAAS</a></h3>
       <p>MAAS (Metal as a Service) offers cloud style provisioning for physical servers.</p>
     </div>
@@ -43,68 +43,68 @@ copydoc: https://docs.google.com/document/d/1daLrp_H_BGhSefvrP-aj3v3505dEz-zoKF2
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/9ac08e7e-juju-vf.io-showcase.png" alt="Juju screenshot">
+      <img src="https://assets.ubuntu.com/v1/9ac08e7e-juju-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="http://jujucharms.com">Juju</a></h3>
       <p>Juju is an open source, application and service modelling tool.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/c1702401-snapcraft-vf.io-showcase.png" alt="Snapcraft screenshot">
+      <img src="https://assets.ubuntu.com/v1/c1702401-snapcraft-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="http://snapcraft.io">Snapcraft</a></h3>
       <p>Snaps are containerised software packages that are simple to create and install.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/c1ba7c75-lxd-vf.io-showcase.png" alt="LXD screenshot">
+      <img src="https://assets.ubuntu.com/v1/c1ba7c75-lxd-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://linuxcontainers.org">LXD</a></h3>
       <p>LXD is a next generation system container manager.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/ffd04f88-conjure-up-vf.io-showcase.png" alt="Conjure-up screenshot">
+      <img src="https://assets.ubuntu.com/v1/ffd04f88-conjure-up-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://conjure-up.io">Conjure-up</a></h3>
       <p>Conjure-up lets you summon up a big-software stack as a “spell”.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/9eaa474a-cloud-init-vf.io-showcase.png" alt="Cloud-init screenshot">
+      <img src="https://assets.ubuntu.com/v1/9eaa474a-cloud-init-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://cloud-init.io">Cloud-init</a></h3>
       <p>Cloud-init is a package that contains utilities for early initialization of cloud instances.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/f3d58f55-canonical-vf.io-showcase.png" alt="Canonical screenshot">
+      <img src="https://assets.ubuntu.com/v1/f3d58f55-canonical-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://canonical.com">Canonical</a></h3>
       <p>Canonical produces Ubuntu.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/3c5f3958-st-margarets-vf.io-showcase.png" alt="St. Margarets">
+      <img src="https://assets.ubuntu.com/v1/3c5f3958-st-margarets-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://stmargarets.london">St Margarets Community</a></h3>
       <p>Providing residents and visitors information about local news, events and resources.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/34327108-brian-douglass-vf.io-showcase.png" alt="Brian Douglass screenshot">
+      <img src="https://assets.ubuntu.com/v1/34327108-brian-douglass-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://bhdouglass.com">Brian Douglass</a></h3>
       <p>Personal project folio of Software Engineer Brian Douglass.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/f9fa0c42-elm-therapy-vf.io-showcase.png" alt="Elm Therapy screenshot">
+      <img src="https://assets.ubuntu.com/v1/f9fa0c42-elm-therapy-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="http://elmtherapy.co.uk">Elm Therapy</a></h3>
       <p>Massage benefits the whole body, both physiologically and psychologically.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/bb8f1550-psm-limited-vf.io-showcase.png" alt="PSM sreenshot">
+      <img src="https://assets.ubuntu.com/v1/bb8f1550-psm-limited-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="http://psmlimited.com">PSM Limited</a></h3>
       <p>For all your seamless flat roofing, balconies and car park waterproofing.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/54dfa1cc-alice-os-vf.io-showcase.png" alt="AliceOS screenshot">
+      <img src="https://assets.ubuntu.com/v1/54dfa1cc-alice-os-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://aliceos.app">AliceOS</a></h3>
       <p>AliceOS brings new features and experiences to any Ren'Py project.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/4090d18f-development-winslow-vf.io-showcase.png" alt="Notes on development screenshot">
+      <img src="https://assets.ubuntu.com/v1/4090d18f-development-winslow-vf.io-showcase.png" alt="">
       <h3 class="p-heading--four"><a href="https://development.robinwinslow.uk">Notes on development</a></h3>
       <p>Articles and musings about web development, performance, internet security and general tech geekery.</p>
     </div>


### PR DESCRIPTION
## Done

Corrects `alt=` text across the site for improved accessibility.

The problems fall into three main categories:
- Logorrhea: for example, Vanilla is not used by ubuntu logo, jaas logo, and st margarets logo — it is used by Ubuntu, JAAS, and St Margarets.
- Redundancy: using `alt=` simply to name a site or idea (such as “Ubuntu” or “composable”) when an adjacent heading already does that.
- Absence: Some images did not have an `alt=` attribute at all. Even when there should be no `alt` text, `alt=""` is necessary to let screenreaders know that this is deliberate.

In correcting these I’ve followed [the approach prescribed by the HTML spec](https://html.spec.whatwg.org/multipage/images.html#alt). This is the vanillaframework.io equivalent of [ubuntu.com#6109](https://github.com/canonical-web-and-design/ubuntu.com/pull/6109).

## QA

1. Use the site with a screenreader.

## Issue / Card

none

## Screenshots

n/a