### PR TITLE
Upgrade site to Vanilla 2.6.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         <a href="https://docs.vanillaframework.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.5.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.5.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v2.5.0</a>
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.6.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.6.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v2.6.0</a>
       </li>
     </ul>
   </div>
@@ -112,7 +112,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">Download v2.5.0</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">Download v2.6.0</a></p>
         <small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node-sass": "4.13.0",
     "postcss-cli": "6.1.3",
     "sass-lint": "1.13.1",
-    "vanilla-framework": "2.5.0",
+    "vanilla-framework": "2.6.0",
     "watch-cli": "0.2.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,9 +3588,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.5.0.tgz#b7f689d7583f4a215cde39b726091ffc2ec4f62a"
+vanilla-framework@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.6.0.tgz#67077333993824c2aec3578d44269b37ff862923"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Upgraded Vanilla site to 2.6.0

## QA

- ./run or [demo](https://vanillaframework-io-canonical-web-and-design-pr-280.run.demo.haus/)
- go to home page
- check if 2.6.0 is listed as latest release
