### PR TITLE
Bump v2.7.0

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -10,13 +10,13 @@ copydoc: https://docs.google.com/document/d/1_cCvuHSwS9i0pzD_4WHDFoTenVAfZVr9qGx
 
 <div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
-    <h1 class="p-heading--stylized u-no-margin--bottom">Accessibility guidelines</h1>
+    <h1 class="u-no-margin--bottom">Accessibility guidelines</h1>
   </div>
 </div>
 <div class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2 class="p-heading--three">Vanilla aims to be as inclusive as possible.</h2>
+      <h2 class="p-heading--3">Vanilla aims to be as inclusive as possible.</h2>
       <p>While traditionally accessibility focuses on making the web more accessible for users with permanent disabilities, a focus on accessibility can deliver an improved user experience for everyone, including those with a temporary or circumstantial disability.</p>
       <p>Accessibility should permeate the entire design and development process, rather than being something that you only think about after everything else has been defined and implemented. You should focus on accessibility when you are:</p>
       <ul>
@@ -30,7 +30,7 @@ copydoc: https://docs.google.com/document/d/1_cCvuHSwS9i0pzD_4WHDFoTenVAfZVr9qGx
 <div class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2 class="p-heading--three">Accessibility testing</h2>
+      <h2 class="p-heading--3">Accessibility testing</h2>
       <p>Ideally, prototypes should be tested with real users with real accessibility issues, but that is not always possible.</p>
       <p>If you are not able to test design patterns with real users, have a look at Anne Gibson’s "<a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31" class="p-link--external">Accessibility Alphabet</a>" to consider a few real-world scenarios that might hamper a user’s accessibility. Can you improve these users’ access to content and features?</p>
       <p>Use the following checklist to make sure your design patterns are designed and built to be accessible*:</p>

--- a/browser-support.html
+++ b/browser-support.html
@@ -9,13 +9,13 @@ copydoc: https://docs.google.com/document/d/1flcSinNnjOJw88ooVQfUjQW8ZDHSXOe2cTH
 ---
 <div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
-    <h1 class="p-heading--stylized u-no-margin--bottom">Browser support</h1>
+    <h1 class="u-no-margin--bottom">Browser support</h1>
   </div>
 </div>
 <div class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <p class="p-heading--four">Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design components do not have to look exactly the same on every browser.</p>
+      <p class="p-heading--4">Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design components do not have to look exactly the same on every browser.</p>
     </div>
   </div>
 </div>

--- a/contribute.html
+++ b/contribute.html
@@ -10,7 +10,7 @@ copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv3
 
 <div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
-    <h1 class="p-heading--stylized u-no-margin--bottom">Contribute</h1>
+    <h1 class="u-no-margin--bottom">Contribute</h1>
   </div>
 </div>
 <div class="p-strip is-bordered">

--- a/index.html
+++ b/index.html
@@ -137,19 +137,19 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
   <div class="row">
     <div class="col-3">
       <h4><a href="https://ubuntu.com/blog/the-lifecycle-of-components-in-your-design-system">The lifecycle of a component</a></h4>
-      <p class="p-heading--six">21 November 2019</p>
+      <p class="p-heading--6">21 November 2019</p>
     </div>
     <div class="col-3">
       <h4><a href="https://ubuntu.com/blog/vanilla-framework-2-0-upgrade-guide">Vanilla Framework 2.0 upgrade guide</a></h4>
-      <p class="p-heading--six">20 June 2019</p>
+      <p class="p-heading--6">20 June 2019</p>
     </div>
     <div class="col-3">
       <h4><a href="https://ubuntu.com/blog/new-release-vanilla-framework-2-0">New release: Vanilla framework 2.0</a></h4>
-      <p class="p-heading--six">13 June 2019</p>
+      <p class="p-heading--6">13 June 2019</p>
     </div>
     <div class="col-3">
       <h4><a href="https://ubuntu.com/blog/a-fresh-look-for-releases-ubuntu-com">A fresh look for releases.ubuntu.com</a></h4>
-      <p class="p-heading--six">13 February 2019</p>
+      <p class="p-heading--6">13 February 2019</p>
     </div>
   </div>
   <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
@@ -187,12 +187,12 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
 <div class="p-strip--light">
   <div class="row">
     <div class="col-3">
-      <h2 class="p-heading--three">Contribute</h2>
+      <h2 class="p-heading--3">Contribute</h2>
       <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
       <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
     </div>
     <div class="col-3">
-      <h2 class="p-heading--three">Get involved</h2>
+      <h2 class="p-heading--3">Get involved</h2>
       <ul class="p-list--divided">
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg'); background-size: 1rem;">
           <a href="https://vanillaframework.slack.com" class="p-link--soft">Slack&nbsp;&rsaquo;</a>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         <a href="https://docs.vanillaframework.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.6.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.6.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v2.6.0</a>
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.7.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.7.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v2.7.0</a>
       </li>
     </ul>
   </div>
@@ -112,7 +112,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">Download v2.6.0</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">Download v2.7.0</a></p>
         <small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node-sass": "4.13.0",
     "postcss-cli": "6.1.3",
     "sass-lint": "1.13.1",
-    "vanilla-framework": "2.6.0",
+    "vanilla-framework": "2.7.0",
     "watch-cli": "0.2.3"
   },
   "dependencies": {

--- a/showcase.html
+++ b/showcase.html
@@ -16,7 +16,7 @@ copydoc: https://docs.google.com/document/d/1daLrp_H_BGhSefvrP-aj3v3505dEz-zoKF2
 
 <section class="p-strip u-no-padding--bottom">
   <div class="row">
-    <p class="p-heading--four">Real life example websites, documentation websites and Cloud applications using Vanilla as the base CSS framework for their projects.</p>
+    <p class="p-heading--4">Real life example websites, documentation websites and Cloud applications using Vanilla as the base CSS framework for their projects.</p>
   </div>
 </section>
 
@@ -27,16 +27,16 @@ copydoc: https://docs.google.com/document/d/1daLrp_H_BGhSefvrP-aj3v3505dEz-zoKF2
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/25df3b87-ubuntu-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="http://ubuntu.com">Ubuntu</a></h3>
+      <h3 class="p-heading--4"><a href="http://ubuntu.com">Ubuntu</a></h3>
       <p>Ubuntu is an open source software operating system.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/e8ea14f4-maas-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="http://maas.io">MAAS</a></h3>
+      <h3 class="p-heading--4"><a href="http://maas.io">MAAS</a></h3>
       <p>MAAS (Metal as a Service) offers cloud style provisioning for physical servers.</p>
     </div>
     <div class="col-4 p-card" style="background-color: #f7f7f7;">
-      <h3 class="p-heading--four">Use Vanilla in your projects</h3>
+      <h3 class="p-heading--4">Use Vanilla in your projects</h3>
       <p>View our documentation to find out different ways of adding Vanilla framework into your projects.</p>
       <a href="https://docs.vanillaframework.io" class="p-button--positive">Get started with Vanilla</a>
     </div>
@@ -44,63 +44,63 @@ copydoc: https://docs.google.com/document/d/1daLrp_H_BGhSefvrP-aj3v3505dEz-zoKF2
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/9ac08e7e-juju-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="http://jujucharms.com">Juju</a></h3>
+      <h3 class="p-heading--4"><a href="http://jujucharms.com">Juju</a></h3>
       <p>Juju is an open source, application and service modelling tool.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/c1702401-snapcraft-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="http://snapcraft.io">Snapcraft</a></h3>
+      <h3 class="p-heading--4"><a href="http://snapcraft.io">Snapcraft</a></h3>
       <p>Snaps are containerised software packages that are simple to create and install.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/c1ba7c75-lxd-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://linuxcontainers.org">LXD</a></h3>
+      <h3 class="p-heading--4"><a href="https://linuxcontainers.org">LXD</a></h3>
       <p>LXD is a next generation system container manager.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/ffd04f88-conjure-up-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://conjure-up.io">Conjure-up</a></h3>
+      <h3 class="p-heading--4"><a href="https://conjure-up.io">Conjure-up</a></h3>
       <p>Conjure-up lets you summon up a big-software stack as a “spell”.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/9eaa474a-cloud-init-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://cloud-init.io">Cloud-init</a></h3>
+      <h3 class="p-heading--4"><a href="https://cloud-init.io">Cloud-init</a></h3>
       <p>Cloud-init is a package that contains utilities for early initialization of cloud instances.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/f3d58f55-canonical-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://canonical.com">Canonical</a></h3>
+      <h3 class="p-heading--4"><a href="https://canonical.com">Canonical</a></h3>
       <p>Canonical produces Ubuntu.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/3c5f3958-st-margarets-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://stmargarets.london">St Margarets Community</a></h3>
+      <h3 class="p-heading--4"><a href="https://stmargarets.london">St Margarets Community</a></h3>
       <p>Providing residents and visitors information about local news, events and resources.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/34327108-brian-douglass-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://bhdouglass.com">Brian Douglass</a></h3>
+      <h3 class="p-heading--4"><a href="https://bhdouglass.com">Brian Douglass</a></h3>
       <p>Personal project folio of Software Engineer Brian Douglass.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/bb8f1550-psm-limited-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="http://psmlimited.com">PSM Limited</a></h3>
+      <h3 class="p-heading--4"><a href="http://psmlimited.com">PSM Limited</a></h3>
       <p>For all your seamless flat roofing, balconies and car park waterproofing.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/54dfa1cc-alice-os-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://aliceos.app">AliceOS</a></h3>
+      <h3 class="p-heading--4"><a href="https://aliceos.app">AliceOS</a></h3>
       <p>AliceOS brings new features and experiences to any Ren'Py project.</p>
     </div>
     <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/4090d18f-development-winslow-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--four"><a href="https://development.robinwinslow.uk">Notes on development</a></h3>
+      <h3 class="p-heading--4"><a href="https://development.robinwinslow.uk">Notes on development</a></h3>
       <p>Articles and musings about web development, performance, internet security and general tech geekery.</p>
     </div>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,9 +3588,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.6.0.tgz#67077333993824c2aec3578d44269b37ff862923"
+vanilla-framework@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.7.0.tgz#3acb67982ff758b36c6e1fc9396ed08776cbf3b3"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Updates version of Vanilla to 2.7.0
- Updates headings to use new numbered classes

## QA

- `./run` the site or use [demo](https://vanillaframework-io-canonical-web-and-design-pr-283.run.demo.haus/)
- make sure latest version is 2.7.0
- make sure headings look as expected

