### PR TITLE
Don't cache status check

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,12 @@ server {
         rewrite ^/(.*[^/])$ /$1/ permanent;
     }
 
+    # Don't cache status check
+    location ~ ^/_status {
+      try_files $uri $uri.html $uri/ =404;
+      expires epoch;
+    }
+
     # For finding files from URIs
     # First try the URI directly, then try adding .html, then try treating it as a directory
     # Finally fall back to 404


### PR DESCRIPTION
## Done

Updates nginx configuration to remove /_status/check from cache
Fixes #285 

## QA

- `docker build --build-arg REVISION_ID=test -t vfio .`
- `docker run -ti -p 8123:80 vfio`
- Go to http://localhost:8123
- Make sure pages are served with standard cache headers
- Go to http://localhost:8123/_status/check
- Make sure cache control is set to no-cache (and long expired)
