### PR TITLE
Remove references of latest Vanilla version number from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
         <a href="https://docs.vanillaframework.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.7.0" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v2.7.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v2.7.0</a>
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download Vanilla</a>
       </li>
     </ul>
   </div>
@@ -112,7 +112,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">Download v2.7.0</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest release</a></p>
         <small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>


### PR DESCRIPTION
## Done

To avoid immediate need to deploy vanillaframework.io site on every release we remove any mentions of latest version number from the home page.

All links will still correctly link to latest release thanks to GH support for linking latest release automatically.

Fixes #284 

## QA

- ./run or [demo](https://vanillaframework-io-canonical-web-and-design-pr-287.run.demo.haus/)
- go to home page
- There should be no v2.7.0 in download buttons on the page
- Buttons should correctly link to latest release on GH

## Screenshots

<img width="1155" alt="Screenshot 2020-02-19 at 11 22 49" src="https://user-images.githubusercontent.com/83575/74826648-3dd05d80-530c-11ea-814b-3d92369254a2.png">

